### PR TITLE
Update routes for production worker

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,10 +1,15 @@
 name = "webhook-typer"
-route = "webhook-typer.inngest.workers.dev/*"
 vars = { ENVIRONMENT = "production" }
 type = "javascript"
 
 account_id = ""
-workers_dev = true
+zone_id = ""
+
+routes = [
+  "typedwebhook.tools/webhook/*",
+  "typedwebhook.tools/ws/*",
+  "typedwebhook.tools/new_webhook"
+]
 
 compatibility_date = "2022-02-11"
 compatibility_flags = []
@@ -35,5 +40,6 @@ durable_objects_persist = true
 
 [env.staging]
 name = "webhook-typer-staging"
+workers_dev = true
 route = "webhook-typer-staging.inngest.workers.dev/*"
 vars = { ENVIRONMENT = "staging" }


### PR DESCRIPTION
This adds the production routes to the new Pages domain.

We need to add `account_id` and `zone_id` to `wrangler.toml` to successfully deploy.